### PR TITLE
Fix segfault on malformed taiko hitobjects

### DIFF
--- a/oppai.c
+++ b/oppai.c
@@ -1841,6 +1841,10 @@ int d_taiko(ezpp_t ez) {
       cur->time_elapsed = 0;
     }
 
+    if (!o->sound_types) {
+      return ERR_SYNTAX;
+    }
+
     cur->strain = 1;
     cur->same_since = 1;
     cur->last_switch_even = -1;


### PR DESCRIPTION
o.sound_types could be null if the hitobject line had less than 5 commas.

Example:
```
[General]
Mode: 1
[HitObjects]
invalid
```

I wasn't really sure what to return because it's not a parsing function, but ERR_SYNTAX seems close enough