### PR TITLE
Add Rust implementation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ should pass the same test suite that oppai-ng passes.
 * [oppai5 (golang)](https://github.com/flesnuk/oppai5) (by flesnuk)
 * [OppaiSharp (C#)](https://github.com/HoLLy-HaCKeR/OppaiSharp)
   (by HoLLy)
+* [ezpp (rust)](https://gitlab.com/JackRedstonia/ezpp/)
 
 # bindings for other programming languages
 thanks to swig it's trivial to generate native bindings for other
@@ -114,7 +115,6 @@ that you get basically the same performance as C by sacrificing some
 portability
 
 * [python](https://github.com/Francesco149/oppai-ng/swig/python)
-* [rust](https://gitlab.com/JackRedstonia/ezpp/)
 
 # oppai-ng vs old oppai
 executable size is around 7 times smaller:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ that you get basically the same performance as C by sacrificing some
 portability
 
 * [python](https://github.com/Francesco149/oppai-ng/swig/python)
+* [rust](https://gitlab.com/JackRedstonia/ezpp/)
 
 # oppai-ng vs old oppai
 executable size is around 7 times smaller:


### PR DESCRIPTION
I'm brewing up a Rust implementation of this library over at https://gitlab.com/JackRedstonia/ezpp/. However, it is still a work-in-progress, so I am keeping this pull request as a draft until it is ready for others to use.