### PR TITLE
Change ezpp to osu-perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ should pass the same test suite that oppai-ng passes.
 * [oppai5 (golang)](https://github.com/flesnuk/oppai5) (by flesnuk)
 * [OppaiSharp (C#)](https://github.com/HoLLy-HaCKeR/OppaiSharp)
   (by HoLLy)
-* [ezpp (rust)](https://gitlab.com/JackRedstonia/ezpp/)
+* [osu-perf (rust)](https://gitlab.com/JackRedstonia/osu-perf/)
 
 # bindings for other programming languages
 thanks to swig it's trivial to generate native bindings for other


### PR DESCRIPTION
Currently being harassed into renaming this library because of a name clash with a browser extension for osu!. My apologies.